### PR TITLE
Entrypoint.sh: use common way to execute argument given

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,5 +12,5 @@ if [ "${USER_ID}" -ne "0" ]; then
 
   /usr/local/bin/gosu ${USER_NAME} /bin/bash -c "${CMD}"
 else
-  /bin/bash -c "${CMD}"
+  exec "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,14 +3,13 @@
 USER_NAME=${USER:-root}
 USER_ID=${LOCAL_USER_ID:-0}
 GROUP_ID=${LOCAL_GROUP_ID:-0}
-CMD=${*:-/bin/bash}
 
 if [ "${USER_ID}" -ne "0" ]; then
   groupadd -g ${GROUP_ID} ${USER_NAME} &> /dev/null
   useradd --shell /bin/bash -M -u ${USER_ID} -g ${GROUP_ID} -o -c "" ${USER_NAME}
   usermod -aG sudo ${USER_NAME}
 
-  /usr/local/bin/gosu ${USER_NAME} /bin/bash -c "${CMD}"
+  /usr/local/bin/gosu ${USER_NAME} /bin/bash -c "$@"
 else
   exec "$@"
 fi


### PR DESCRIPTION
This fixes issue #8 (https://github.com/lindt/docker-ldc/issues/8 ), where the previous way resulted in a failure with gitlab's CI. (see e.g. https://gitlab.com/gitlab-org/gitlab-runner/issues/1253)

